### PR TITLE
AWC.csのバグ修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _ReSharper.*
 bin
 obj
 packages
+src/Properties/PublishProfiles/FolderProfile.pubxml

--- a/src/AWC.cs
+++ b/src/AWC.cs
@@ -301,13 +301,13 @@ namespace CalcsheetGenerator
             string oldtextwep = charname + " add weapon=\"<w>\" refine=<r>";
             string newtextwep = charname + " add weapon=" + "\"" + weaponname + "\"" + " refine=" + refine;
             
-            string oldtextart = charname + " add set=\"<a>\" count=<p>";//置き換え前の文章（聖遺物）
+            string oldtextart = charname + " add set=\"<a>\" count=<p>;";//置き換え前の文章（聖遺物）
             string newtextart;//変数だけ作っておく
 
             if (is4pc == true)//聖遺物モード:4セットか2セット混合かで分岐
             {
                 //4セット混合
-                newtextart = charname + " add set=" + "\"" + artiname1 + "\"" + " count=4";//置き換え後の文章（聖遺物）
+                newtextart = charname + " add set=" + "\"" + artiname1 + "\"" + " count=4;";//置き換え後の文章（聖遺物）
             }
             else
             {

--- a/src/AWC.cs
+++ b/src/AWC.cs
@@ -299,7 +299,7 @@ namespace CalcsheetGenerator
         {
             string filename = "../resource/input/config.txt";
             string oldtextwep = charname + " add weapon=\"<w>\" refine=<r>";
-            string newtextwep = charname + " add weapon=" + "\"" + wname + "\"" + " refine=" + refine;
+            string newtextwep = charname + " add weapon=" + "\"" + weaponname + "\"" + " refine=" + refine;
             
             string oldtextart = charname + " add set=\"<a>\" count=<p>";//置き換え前の文章（聖遺物）
             string newtextart;//変数だけ作っておく

--- a/src/AWC.cs
+++ b/src/AWC.cs
@@ -275,6 +275,7 @@ namespace CalcsheetGenerator
             }
 
             DataTableToCsv(table, "table_" + artiname1 + artiname2 + ".csv", true);
+            lines.Clear();//次の聖遺物のため書き出し用リストを初期化
         }
 
         public static void Txtreplacer(string filename, string oldtext, string newtext) //txtファイルの内容を置き換える

--- a/src/AWC.cs
+++ b/src/AWC.cs
@@ -196,8 +196,11 @@ namespace CalcsheetGenerator
                     aname2 = "";//聖遺物名2にnullが入らないようにする
                 }
 
+
+
                 Console.WriteLine("Initialize calculation for artifact " + aname1 + aname2); //開始メッセージ
                 Weaponcalc(true, table, charname, weapontype, refine, is4pc, aname1, aname2);
+                table.Clear();//次の聖遺物のため書き出し用リストを初期化
                 Console.WriteLine("Calculation completed for artifact " + aname1 + aname2); //終了メッセージ
             }
         }
@@ -275,7 +278,7 @@ namespace CalcsheetGenerator
             }
 
             DataTableToCsv(table, "table_" + artiname1 + artiname2 + ".csv", true);
-            lines.Clear();//次の聖遺物のため書き出し用リストを初期化
+            lines.Clear();//念のためlinesもクリア
         }
 
         public static void Txtreplacer(string filename, string oldtext, string newtext) //txtファイルの内容を置き換える


### PR DESCRIPTION
# Pull Request概要

## やったこと

1. ローカルのVisual Studio用ファイルを.gitignoreに追加
2. 変数名を修正: wname → weaponname
3. artifactmodeの動作を修正;
  - 2pc混合を指定したときに不必要なセミコロンをconfig.txtに書き込んでしまう不具合を修正
  - 複数聖遺物で計算したときに前の聖遺物の表が持ち越されて出力されてしまう不具合を修正

## できるようになること
linter向け修正のやり残しの解消

## 動作確認
https://pastebin.com/g2ixX3Lk - 実行結果
https://pastebin.com/qctfMpgw - 出力csv(1)
https://pastebin.com/Z4gp49S7 - 出力csv(2)